### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,4 +1,6 @@
 name: Check PR
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/publish-apk.yaml
+++ b/.github/workflows/publish-apk.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build_and_deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/defektive/perfect-pitch-counter/security/code-scanning/2](https://github.com/defektive/perfect-pitch-counter/security/code-scanning/2)

To fix the problem, add a `permissions` block specifying the least privilege necessary. Since this workflow only checks out code, sets up environments, installs dependencies, and runs tests, it only needs read access to repository contents. You can set this at the workflow root to apply to all jobs (unless a job needs more and has its own block). The code should be inserted after the workflow's `name:` field and before the `on:` field, using:
```yaml
permissions:
  contents: read
```
No imports or other changes are necessary; just a YAML key addition at the workflow root.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
